### PR TITLE
fix(gitlab): allow autofix commit creation, gate branch creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ Adding a `gitlab` field to the config implicitly adds these endpoints to the all
 - POST `https://gitlab.example.com/api/v4/projects/:project/hooks`
 - POST `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions`
 - POST `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion/notes`
-- POST `https://gitlab.example.com/api/v4/projects/:project/repository/branches`
 - PUT `https://gitlab.example.com/api/v4/groups/:namespace/hooks`
 - PUT `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion`
 - PUT `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion/notes/:note`
@@ -219,6 +218,8 @@ And if `allowCodeAccess` is set, these endpoints are also added to the allowlist
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/merge_base`
 - GET `https://gitlab.example.com/{:namespace/}+:project/info/refs`
 - POST `https://gitlab.example.com/api/v4/projects/:project/merge_requests`
+- POST `https://gitlab.example.com/api/v4/projects/:project/repository/branches`
+- POST `https://gitlab.example.com/api/v4/projects/:project/repository/commits`
 - POST `https://gitlab.example.com/api/v4/projects/:project/statuses/:commit`
 - POST `https://gitlab.example.com/{:namespace/}+:project/git-receive-pack`
 - POST `https://gitlab.example.com/{:namespace/}+:project/git-upload-pack`

--- a/pkg/allowlist_test.go
+++ b/pkg/allowlist_test.go
@@ -233,6 +233,67 @@ func TestAllowlistGitLabSubgroupMatch(t *testing.T) {
 	assertAllowlistMatch(t, allowlist, "DELETE", "https://gitlab.example.com/group/repo.git/info/refs", false)
 }
 
+func gitLabAllowlist(t *testing.T, allowCodeAccess bool) *Allowlist {
+	t.Helper()
+
+	config := &Config{
+		Inbound: InboundProxyConfig{
+			GitLab: &GitLab{
+				BaseURL:         "https://gitlab.example.com/api/v4",
+				AllowCodeAccess: allowCodeAccess,
+			},
+			Allowlist: Allowlist{},
+		},
+	}
+	if err := PopulateAllowLists(config); err != nil {
+		t.Fatalf("PopulateAllowLists: %v", err)
+	}
+
+	return &config.Inbound.Allowlist
+}
+
+// Code Autofix on GitLab creates a branch, writes the fix through the commits
+// endpoint, and then opens an MR. The project is passed URL-encoded, so
+// `:project` has to match a single segment containing %2F.
+func TestAllowlistGitLabAutofixWrites(t *testing.T) {
+	allowlist := gitLabAllowlist(t, true)
+
+	const project = "https://gitlab.example.com/api/v4/projects/caleb-testing%2Fproblems"
+
+	// Create the branch, commit the fix onto it, then open the MR.
+	assertAllowlistMatch(t, allowlist, "POST", project+"/repository/branches", true)
+	assertAllowlistMatch(t, allowlist, "POST", project+"/repository/commits", true)
+	assertAllowlistMatch(t, allowlist, "POST", project+"/merge_requests", true)
+
+	// Reading the same endpoints still works.
+	assertAllowlistMatch(t, allowlist, "GET", project+"/repository/commits", true)
+	assertAllowlistMatch(t, allowlist, "GET", project+"/merge_requests", true)
+
+	// A numeric project id is the other form the platform sends.
+	assertAllowlistMatch(t, allowlist, "POST", "https://gitlab.example.com/api/v4/projects/123/repository/commits", true)
+
+	// Negative: the write verbs stop at the endpoints above.
+	assertAllowlistMatch(t, allowlist, "DELETE", project+"/repository/commits", false)
+	assertAllowlistMatch(t, allowlist, "PUT", project+"/repository/commits", false)
+	assertAllowlistMatch(t, allowlist, "POST", project+"/repository/files/auth.py", false)
+}
+
+func TestAllowlistGitLabAutofixWritesRequireCodeAccess(t *testing.T) {
+	allowlist := gitLabAllowlist(t, false)
+
+	const project = "https://gitlab.example.com/api/v4/projects/caleb-testing%2Fproblems"
+
+	assertAllowlistMatch(t, allowlist, "POST", project+"/repository/commits", false)
+	assertAllowlistMatch(t, allowlist, "GET", project+"/repository/commits", false)
+	assertAllowlistMatch(t, allowlist, "POST", project+"/merge_requests", false)
+	// Creating a branch mutates the repo, so it is gated too.
+	assertAllowlistMatch(t, allowlist, "POST", project+"/repository/branches", false)
+
+	// Sanity check: the read-only entries on the same paths are unaffected.
+	assertAllowlistMatch(t, allowlist, "GET", project+"/merge_requests", true)
+	assertAllowlistMatch(t, allowlist, "GET", project+"/repository/branches", true)
+}
+
 func bitBucketAllowlist(t *testing.T, allowCodeAccess bool) *Allowlist {
 	t.Helper()
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -848,10 +848,11 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
-			// Branches (GET to list; POST to create a branch)
+			// list branches / check existence. Creating a branch (POST) mutates the
+			// repo, so it is gated behind allowCodeAccess below.
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/repository/branches").String(),
-				Methods:           ParseHttpMethods([]string{"GET", "POST"}),
+				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
 			// Get branch
@@ -906,10 +907,17 @@ func PopulateAllowLists(config *Config) error {
 					Methods:           ParseHttpMethods([]string{"GET"}),
 					SetRequestHeaders: headers,
 				},
-				// Commits
+				// create the branch the fix commits onto
+				AllowlistItem{
+					URL:               gitLabBaseUrl.JoinPath("/projects/:project/repository/branches").String(),
+					Methods:           ParseHttpMethods([]string{"POST"}),
+					SetRequestHeaders: headers,
+				},
+				// Commits (GET to list; POST to create the commit carrying the fix,
+				// which is how Code Autofix writes a change on GitLab)
 				AllowlistItem{
 					URL:               gitLabBaseUrl.JoinPath("/projects/:project/repository/commits").String(),
-					Methods:           ParseHttpMethods([]string{"GET"}),
+					Methods:           ParseHttpMethods([]string{"GET", "POST"}),
 					SetRequestHeaders: headers,
 				},
 				// Compare branches


### PR DESCRIPTION
## What

Code Autofix on GitLab was blocked by the broker:

```
WARN allowlist.reject method=POST
path="/proxy/https://gitlab.example.com/api/v4/projects/:project/repository/commits"
```

`/projects/:project/repository/commits` was allowlisted but **GET-only**, so the POST that writes the fix failed the method check. Unlike GitHub, the platform doesn't push the fix over the git transfer protocol on GitLab — it creates the commit through the REST API — so `git-receive-pack` already being allowed wasn't enough.

This PR:

1. **Adds `POST` to `/projects/:project/repository/commits`** in the `allowCodeAccess` block. That completes the autofix flow — create branch → commit the fix → open the MR. The other two legs were already allowed.

2. **Moves `POST /projects/:project/repository/branches`** out of the implicit allowlist and into `allowCodeAccess`, matching the Bitbucket Data Center precedent from #226.

## Why the branch move

#221 added the create-branch verb to the existing GET entry for GitLab, Bitbucket DC, and Azure DevOps. #226 then split Bitbucket's out into `allowCodeAccess`, on the grounds that creating a branch mutates the repo and belongs behind the code-access gate. GitLab was left as the odd one out: a deployment with `allowCodeAccess: false` could still create branches.

Branch creation only exists to serve autofix, which needs code access regardless, so nothing that previously worked end-to-end regresses. Worth noting explicitly, though: **this is a behavior change** for any deployment running `gitlab` with `allowCodeAccess: false` that creates branches for some other reason — those calls will now be rejected.

**Azure DevOps is deliberately left alone.** It still has `POST .../_apis/git/repositories/:repo/refs` in its implicit allowlist. ADO autofix is still in development and under active testing; moving it now would disrupt that. Worth a follow-up once ADO autofix lands.

## Testing

Verified end-to-end against a GLSM instance scanning through the broker on a dev stack — autofix now completes where it previously failed on the rejected POST.

New tests cover both directions:

- `TestAllowlistGitLabAutofixWrites` — with `allowCodeAccess`, all three writes are permitted, including a URL-encoded `namespace%2Fproject` path (the form the platform actually sends, which exercises `:project` matching a single segment containing `%2F`).
- `TestAllowlistGitLabAutofixWritesRequireCodeAccess` — without it, all three are rejected, while the read-only entries on the same paths keep working.

`go test ./...` passes.

README allowlist tables regenerated via `tools/readme-url-populator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)