### PR TITLE
fix(github): allow autofix ref lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ And if `allowCodeAccess` is set, these endpoints are also added to the allowlist
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/commits`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/contents`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/contents/*`
+- GET `https://github.example.com/api/v3/repos/:owner/:repo/git/ref/*`
 - POST `https://github.example.com/:owner/:repo/git-receive-pack`
 - POST `https://github.example.com/:owner/:repo/git-upload-pack`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls`

--- a/pkg/allowlist_test.go
+++ b/pkg/allowlist_test.go
@@ -233,6 +233,71 @@ func TestAllowlistGitLabSubgroupMatch(t *testing.T) {
 	assertAllowlistMatch(t, allowlist, "DELETE", "https://gitlab.example.com/group/repo.git/info/refs", false)
 }
 
+func gitHubAllowlist(t *testing.T, allowCodeAccess bool) *Allowlist {
+	t.Helper()
+
+	config := &Config{
+		Inbound: InboundProxyConfig{
+			GitHub: &GitHub{
+				BaseURL:         "https://github.example.com/api/v3",
+				AllowCodeAccess: allowCodeAccess,
+			},
+			Allowlist: Allowlist{},
+		},
+	}
+	if err := PopulateAllowLists(config); err != nil {
+		t.Fatalf("PopulateAllowLists: %v", err)
+	}
+
+	return &config.Inbound.Allowlist
+}
+
+// Code Autofix on GitHub resolves the base branch SHA, creates a branch at that
+// SHA, pushes the fix over the git transfer protocol, and opens a PR. The SHA
+// lookup was missing from the allowlist, so the branch was created with the
+// branch name in place of the SHA and GitHub rejected it with a 422.
+func TestAllowlistGitHubAutofixWrites(t *testing.T) {
+	allowlist := gitHubAllowlist(t, true)
+
+	const repo = "https://github.example.com/api/v3/repos/testorg/testrepo"
+
+	// Resolve the base SHA, create the branch at it, push the fix, open the PR.
+	assertAllowlistMatch(t, allowlist, "GET", repo+"/git/ref/heads/main", true)
+	assertAllowlistMatch(t, allowlist, "POST", repo+"/git/refs", true)
+	assertAllowlistMatch(t, allowlist, "POST", "https://github.example.com/testorg/testrepo/git-receive-pack", true)
+	assertAllowlistMatch(t, allowlist, "POST", repo+"/pulls", true)
+
+	// Ref names contain slashes, so the lookup must match across segments.
+	assertAllowlistMatch(t, allowlist, "GET", repo+"/git/ref/heads/feature/DEV-1/fix", true)
+	assertAllowlistMatch(t, allowlist, "GET", repo+"/git/ref/tags/v1.2.3", true)
+
+	// Reading the repo (for its default branch) still works.
+	assertAllowlistMatch(t, allowlist, "GET", repo, true)
+
+	// Negative: the ref lookup is read-only, and does not widen /git/refs.
+	assertAllowlistMatch(t, allowlist, "POST", repo+"/git/ref/heads/main", false)
+	assertAllowlistMatch(t, allowlist, "DELETE", repo+"/git/ref/heads/main", false)
+	assertAllowlistMatch(t, allowlist, "PATCH", repo+"/git/refs/heads/main", false)
+	assertAllowlistMatch(t, allowlist, "GET", repo+"/git/refs", false)
+}
+
+// The SHA lookup reads repository contents, so it is gated behind
+// allowCodeAccess alongside the push and the PR create.
+func TestAllowlistGitHubAutofixWritesRequireCodeAccess(t *testing.T) {
+	allowlist := gitHubAllowlist(t, false)
+
+	const repo = "https://github.example.com/api/v3/repos/testorg/testrepo"
+
+	assertAllowlistMatch(t, allowlist, "GET", repo+"/git/ref/heads/main", false)
+	assertAllowlistMatch(t, allowlist, "POST", "https://github.example.com/testorg/testrepo/git-receive-pack", false)
+	assertAllowlistMatch(t, allowlist, "POST", repo+"/pulls", false)
+
+	// Sanity check: the read-only entries on neighbouring paths are unaffected.
+	assertAllowlistMatch(t, allowlist, "GET", repo, true)
+	assertAllowlistMatch(t, allowlist, "GET", repo+"/branches/main", true)
+	assertAllowlistMatch(t, allowlist, "GET", repo+"/pulls", true)
+}
+
 func gitLabAllowlist(t *testing.T, allowCodeAccess bool) *Allowlist {
 	t.Helper()
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -742,6 +742,14 @@ func PopulateAllowLists(config *Config) error {
 					Methods:           ParseHttpMethods([]string{"POST"}),
 					SetRequestHeaders: headers,
 				},
+				// resolve the base branch SHA before creating the autofix branch.
+				// A wildcard, not :ref — ref names span path segments ("heads/main",
+				// "heads/feature/DEV-1/fix") and :ref only matches a single one.
+				AllowlistItem{
+					URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo/git/ref/*").String(),
+					Methods:           ParseHttpMethods([]string{"GET"}),
+					SetRequestHeaders: headers,
+				},
 				// create pull request
 				AllowlistItem{
 					URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo/pulls").String(),


### PR DESCRIPTION
Code Autofix failed for every deployment reaching GitHub through the broker:

    HTTP 422: Invalid request.
    At least 40 characters are required; only 4 were supplied.

Creating the autofix branch resolves the base SHA via GET /repos/:owner/:repo/git/ref/{ref}, which was never allowlisted. The broker 403'd it, the platform fell through to POST .../git/refs with the branch name where the SHA belongs, and that POST was already allowed — so GitHub's validation error surfaced instead of the rejection. "main" is four characters.

Add GET /repos/:owner/:repo/git/ref/* to the allowCodeAccess block. The other three legs — create branch, push over git, open PR — were already allowed, so this one read is the whole gap.

Wildcard rather than :ref: matching uses go-urlpattern, where :param covers a single segment and ref names span them ("heads/main"). Gated behind allowCodeAccess per the #226 and #228 precedent.

GitHub was skipped by #221 because #201 and #202 had already added the write leg; nobody noticed the read side was missing. The 0.45.1 fixes covered GitLab and Bitbucket Data Center only.

Tests cover both directions: with allowCodeAccess the four legs pass, including slashed and tag refs; without it the writes are rejected while neighbouring read-only entries keep working. Negatives pin the wildcard off /git/refs and other methods.